### PR TITLE
Add keyboard navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -419,7 +419,8 @@ body {
 	user-select: none;
 	transition: 0.2s ease-out;
 }
-.BUTTON-set-location:hover {
+.BUTTON-set-location:hover,
+.BUTTON-set-location.selected {
 	cursor: pointer;
 	background-color: var(--theme-color);
 	color: var(--theme-color-dark);

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -2,6 +2,7 @@ let showSettingsWindow = false;
 let showCreditsWindow = false;
 let showMapWindow = false;
 let hoverLocation = null;
+let locationSelectedIndex = -1;
 
 document.getElementById('BUTTON-open-settings').addEventListener('click', function (e) { toggleSettingsWindow(); });
 document.getElementById('BUTTON-close-settings').addEventListener('click', function (e) { toggleSettingsWindow(); });
@@ -23,6 +24,7 @@ function toggleSettingsWindow(forceState = null) {
 	} else {
 		document.getElementById('location-selection-input').value = '';
 		document.getElementById('location-selection-input').blur();
+		resetLocationList();
 	}
 
 }
@@ -194,6 +196,8 @@ document.getElementById('location-selection-input').addEventListener('input', (e
 		return;
 	}
 
+	resetLocationList();
+
 	let searchFragments = search.split('+');
 	let buttons = document.getElementsByClassName('BUTTON-set-location');
 
@@ -215,6 +219,19 @@ document.getElementById('time-selection-input').addEventListener('input', (event
 	setChosenTime(timeInput);
 });
 
+function removeSelectedClass() {
+	document.getElementById('available-locations-list').querySelectorAll('.BUTTON-set-location:not(.hide).selected').forEach(el => el.classList.remove('selected'))
+}
+
+function getLocationButtons() {
+	return document.getElementById('available-locations-list').querySelectorAll('.BUTTON-set-location:not(.hide)');
+}
+
+function resetLocationList() {
+	locationSelectedIndex = -1;
+	removeSelectedClass();
+	document.getElementById('available-locations-list').scroll(0, 0);
+}
 
 // KEYBOARD INPUT
 document.addEventListener('keydown', function (event) {
@@ -224,6 +241,49 @@ document.addEventListener('keydown', function (event) {
 		if (window.DEBUG_MODE) toggleDebugWindow();
 	}
 
+
+	if(event.keyCode === 38) { // Up
+		if(locationSelectedIndex <= 0) {
+			document.getElementById('location-selection-input').focus();
+			return;
+		}
+		let buttons = getLocationButtons();
+		removeSelectedClass();
+
+		locationSelectedIndex--;
+		buttons[locationSelectedIndex].classList.add('selected');
+
+		// scroll to button
+		document.getElementById('available-locations-list').scroll(0, buttons[locationSelectedIndex].offsetTop - 200);
+	}
+
+	if(event.keyCode === 40) { // Down
+		let buttons = getLocationButtons();
+		if(locationSelectedIndex >= buttons.length - 1) {
+			return;
+		}
+		document.getElementById('location-selection-input').blur();
+		removeSelectedClass();
+
+		locationSelectedIndex++;
+		buttons[locationSelectedIndex].classList.add('selected');
+
+		// scroll to button
+		document.getElementById('available-locations-list').scroll(0, buttons[locationSelectedIndex].offsetTop - 200);
+	}
+
+
+	if (event.keyCode === 13 && showSettingsWindow) {
+		let selected = document.querySelector('.BUTTON-set-location.selected');
+		let result = getLocationButtons();
+		if(selected) {
+			selected.click();
+			resetLocationList();
+		} else if(result && result.length > 0) {
+			result[0].click();
+			resetLocationList();
+		}
+	}
 
 	if (event.target.tagName.toLowerCase() === 'input') { return; }
 

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -21,6 +21,7 @@ function toggleSettingsWindow(forceState = null) {
 	if (showSettingsWindow) {
 		document.getElementById('location-selection-input').focus();
 	} else {
+		document.getElementById('location-selection-input').value = '';
 		document.getElementById('location-selection-input').blur();
 	}
 
@@ -187,16 +188,16 @@ function populateLocationList() {
 // LOCATION SEARCH FILTER
 document.getElementById('location-selection-input').addEventListener('input', (event) => {
 	let search = document.getElementById("location-selection-input").value.toLowerCase();
+	if (search === '/' || search === '') {
+		document.getElementById('location-selection-input').value = '';
+		document.getElementById('available-locations-list').querySelectorAll('.BUTTON-set-location.hide').forEach(el => el.classList.remove('hide'))
+		return;
+	}
+
 	let searchFragments = search.split('+');
 	let buttons = document.getElementsByClassName('BUTTON-set-location');
 
 	for (let element of buttons) {
-
-		if (search === '') {
-			element.classList.remove('hide');
-			continue;
-		}
-
 		let found = Array();
 		for (let [index, fragment] of searchFragments.entries()) {
 			if (fragment === '') continue;
@@ -240,7 +241,6 @@ document.addEventListener('keydown', function (event) {
 
 	if (event.keyCode === 191) {
 		toggleSettingsWindow('on');
-		document.getElementById('location-selection-input').blur();
 	}
 });
 


### PR DESCRIPTION
This PR adds keyboard navigation.
Pressing `/` keeps the input field focused. 
Using the arrow keys `up`/`down` allows navigating through the results.
Hit `enter` to show the location. Hitting `enter` without selecting anything will always open the first location in the list.