### PR TITLE
Add keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can filter locations in the search interface in a variety of ways:
 * Combine queries using the **[ + ]** symbol: e.g. "Daymar+Afternoon" will return all locations on Daymar where the local time is in the afternoon.
 
 Pressing <kbd>Enter</kbd> will switch to the first location in the filtered list.
+Locations can be selected with the <kbd>Up</kbd> and <kbd>Down</kbd> arrow keys.
 
 ## Sharing
 Click the "Share" button at the top center of the window. A URL pointing to your currently displayed location will be copied to your clipboard. You can share this URL with others or use it to bookmark your favorite locations for quick access.

--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -1,4 +1,4 @@
-﻿import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
+import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
 import Settings from './Preferences.js';
 import DB from './Database.js';
 import Window from './Window.js';
@@ -131,12 +131,13 @@ class UserInterface {
 		document.addEventListener('keyup', (event) => {
 			if (UI.Settings.show && event.key === 'Enter') {
 				let selected = this.getSelectedButton();
-				let buttons = this.getVisibleButtons();
 				if(selected) {
-					selected.click();
 					UI.setMapLocation(selected.dataset.locationName);
-				} else if(buttons && buttons.length > 0) {
-					buttons[0].click();
+					return;
+				}
+
+				let buttons = this.getVisibleButtons();
+				if(buttons && buttons.length > 0) {
 					UI.setMapLocation(buttons[0].dataset.locationName);
 				}
 				return;

--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -1,4 +1,4 @@
-﻿import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
+import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
 import Settings from './Preferences.js';
 import DB from './Database.js';
 import Window from './Window.js';
@@ -76,7 +76,7 @@ class UserInterface {
 
 		// KEYBOARD SEARCH
 		document.addEventListener('keyup', (event) => {
-			if (UI.Settings.show && event.key === 'Enter') { 
+			if (UI.Settings.show && event.key === 'Enter') {
 				const buttons = document.getElementsByClassName('BUTTON-set-location');
 				const visible = [...buttons].filter((button) => !button.classList.contains('hide'));
 				
@@ -97,7 +97,7 @@ class UserInterface {
 		// CUSTOM TIME SELECTION
 		this.listen('input', 'time-selection-input', () => {
 			const timeInput = UI.el('time-selection-input').value;
-			UI.setCustomTime(timeInput); 
+			UI.setCustomTime(timeInput);
 		})
 
 
@@ -113,7 +113,7 @@ class UserInterface {
 				}
 				return;
 			}
-			
+
 			for (const element of buttons) {
 				const found = Array();
 				for (let [index, fragment] of searchFragments.entries()) {
@@ -580,7 +580,7 @@ class UserInterface {
 				return (a.ORDINAL < b.ORDINAL) ? -1 : (a.ORDINAL > b.ORDINAL) ? 1 : 0;
 			});
 
-			
+
 			const ul2 = document.createElement('ul');
 			if (planets.length > 0) {
 				li1.appendChild(ul2);

--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -514,7 +514,7 @@ class UserInterface {
 			this.locationSelectedIndex = -1;
 			this.getSelectedButton()?.classList.remove('selected');
 			this.getButtons()?.forEach(el => el.classList.remove('hide'));
-			document.getElementById('available-locations-list').scroll(0, 0);
+			UI.el('available-locations-list').scroll(0, 0);
 		}
 
 		window.suppressReload = true;

--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -1,4 +1,4 @@
-import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
+﻿import { round, getHashedLocation, getHash, convertHoursToTimeString, getCustomTime, convertDateToShortTime, getUniverseTime, getLocationByName } from '../../HelperFunctions.js';
 import Settings from './Preferences.js';
 import DB from './Database.js';
 import Window from './Window.js';
@@ -22,12 +22,26 @@ class UserInterface {
 		this.atlasInfobox = document.getElementById('atlas-hoverinfo');
 
 		this.mapHoverLocation = null;
+		this.locationSelectedIndex = -1;
+		this.visibleButtons = [];
 
 		this.Atlas = new Window('modal-atlas', 'atlas-container', 'createAtlasScene');
 		this.Map = new Window('modal-map', 'map-window', 'createMapScene');
 		this.Settings = new Window('modal-settings', 'settings-window', null);
 		this.Debug = new Window('detailed-info', null, null);
 		this.Credits = new Window('modal-credits', null, null);
+	}
+
+	getButtons() {
+		return document.getElementById('available-locations-list').querySelectorAll('.BUTTON-set-location');
+	}
+
+	getVisibleButtons() {
+		return document.getElementById('available-locations-list').querySelectorAll('.BUTTON-set-location:not(.hide)');
+	}
+
+	getSelectedButton() {
+		return document.getElementById('available-locations-list').querySelector('.BUTTON-set-location.selected');
 	}
 
 	setupEventListeners() {
@@ -58,6 +72,43 @@ class UserInterface {
 
 				return;
 			}
+			if (UI.Settings.show) {
+
+				// get visible buttons once
+				if(this.locationSelectedIndex === -1) {
+					this.buttons = this.getVisibleButtons();
+				}
+
+				if(event.key === 'ArrowUp') {
+					if(this.locationSelectedIndex <= 0) {
+						UI.el('location-selection-input').focus();
+						return;
+					}
+
+					this.getSelectedButton()?.classList.remove('selected');
+					this.locationSelectedIndex--;
+					this.buttons[this.locationSelectedIndex].classList.add('selected');
+
+					// scroll to button
+					document.getElementById('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
+					return;
+				}
+
+				if(event.key === 'ArrowDown') {
+					if(this.locationSelectedIndex >= this.buttons.length - 1) {
+						return;
+					}
+					document.getElementById('location-selection-input').blur();
+					this.getSelectedButton()?.classList.remove('selected');
+
+					this.locationSelectedIndex++;
+					this.buttons[this.locationSelectedIndex].classList.add('selected');
+
+					// scroll to button
+					document.getElementById('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
+					return;
+				}
+			}
 
 			if (event.target.tagName.toLowerCase() === 'input') return;
 
@@ -77,19 +128,26 @@ class UserInterface {
 		// KEYBOARD SEARCH
 		document.addEventListener('keyup', (event) => {
 			if (UI.Settings.show && event.key === 'Enter') {
-				const buttons = document.getElementsByClassName('BUTTON-set-location');
-				const visible = [...buttons].filter((button) => !button.classList.contains('hide'));
-				
-				if (visible.length < 1) return;
-				visible[0].click;
-				UI.setMapLocation(visible[0].dataset.locationName);
+				let selected = this.getSelectedButton();
+				let buttons = this.getVisibleButtons();
+				if(selected) {
+					selected.click();
+					UI.setMapLocation(selected.dataset.locationName);
+				} else if(buttons && buttons.length > 0) {
+					buttons[0].click();
+					UI.setMapLocation(buttons[0].dataset.locationName);
+				}
+				return;
 			}
 
 			if (event.target.tagName.toLowerCase() === 'input') return;
 
 			if (event.key === '/') {
 				if (!UI.Settings.show) UI.Settings.toggle();
+				this.locationSelectedIndex = -1;
+				this.getSelectedButton()?.classList.remove('selected');
 				UI.el('location-selection-input').focus();
+				return;
 			}
 		})
 
@@ -103,14 +161,14 @@ class UserInterface {
 
 		// TYPING IN LOCATION SEARCH BOX
 		this.el('location-selection-input').addEventListener('input', (event) => {
-			const search = UI.el("location-selection-input").value.toLowerCase();
+			const search = UI.el('location-selection-input').value.toLowerCase();
 			const searchFragments = search.split('+');
-			const buttons = document.getElementsByClassName('BUTTON-set-location');
+			const buttons = this.getButtons();
 
 			if (search === '') {
-				for (const element of buttons) {
-					element.classList.remove('hide');
-				}
+				this.locationSelectedIndex = -1;
+				this.getSelectedButton()?.classList.remove('selected');
+				buttons?.forEach(el => el.classList.remove('hide'));
 				return;
 			}
 
@@ -449,7 +507,12 @@ class UserInterface {
 		Settings.save('activeLocation', Settings.activeLocation.NAME);
 		if (UI.Settings.show) {
 			UI.Settings.toggle();
+			UI.el('location-selection-input').value = '';
 			UI.el('location-selection-input').blur();
+			this.locationSelectedIndex = -1;
+			this.getSelectedButton()?.classList.remove('selected');
+			this.getButtons()?.forEach(el => el.classList.remove('hide'));
+			document.getElementById('available-locations-list').scroll(0, 0);
 		}
 
 		window.suppressReload = true;

--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -75,37 +75,39 @@ class UserInterface {
 			if (UI.Settings.show) {
 
 				// get visible buttons once
-				if(this.locationSelectedIndex === -1) {
+				if (this.locationSelectedIndex === -1) {
 					this.buttons = this.getVisibleButtons();
 				}
 
-				if(event.key === 'ArrowUp') {
-					if(this.locationSelectedIndex <= 0) {
+				if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
+					if (event.key === 'Tab') { event.preventDefault(); }
+					if (this.locationSelectedIndex <= 0) {
+						event.preventDefault();
+						this.locationSelectedIndex = -1;
+						this.getSelectedButton()?.classList.remove('selected');
 						UI.el('location-selection-input').focus();
 						return;
 					}
-
+					UI.el('location-selection-input').blur();
 					this.getSelectedButton()?.classList.remove('selected');
 					this.locationSelectedIndex--;
 					this.buttons[this.locationSelectedIndex].classList.add('selected');
 
 					// scroll to button
-					document.getElementById('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
+					UI.el('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
 					return;
 				}
 
-				if(event.key === 'ArrowDown') {
-					if(this.locationSelectedIndex >= this.buttons.length - 1) {
-						return;
-					}
-					document.getElementById('location-selection-input').blur();
+				if (event.key === 'ArrowDown' || event.key === 'Tab') {
+					if (event.key === 'Tab') { event.preventDefault(); }
+					if (this.locationSelectedIndex >= this.buttons.length - 1) { return; }
+					UI.el('location-selection-input').blur();
 					this.getSelectedButton()?.classList.remove('selected');
-
 					this.locationSelectedIndex++;
 					this.buttons[this.locationSelectedIndex].classList.add('selected');
 
 					// scroll to button
-					document.getElementById('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
+					UI.el('available-locations-list').scroll(0, this.buttons[this.locationSelectedIndex].offsetTop - 200);
 					return;
 				}
 			}

--- a/css/location.css
+++ b/css/location.css
@@ -345,7 +345,8 @@
     transition: 0.2s ease-out;
 }
 
-    .BUTTON-set-location:hover {
+    .BUTTON-set-location:hover,
+    .BUTTON-set-location.selected {
         cursor: pointer;
         background-color: var(--theme-color);
         color: var(--theme-color-dark);

--- a/css/style.css
+++ b/css/style.css
@@ -95,7 +95,7 @@ kbd {
 	border-radius: 3px;
 	border: 1px solid var(--theme-color);
 	box-shadow: rgba(0, 0, 0, 0.4) 1px 1px;
-	width: 50px;
+	width: 60px;
 	padding: 2px;
 	background-color: transparent;
 	text-align: center;

--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
                 <div id="credits-keybinds">
                     <kbd>/</kbd><p>Search locations</p>
                     <kbd>Enter</kbd><p>Switch to first location in filtered list</p>
+                    <kbd>Up/Down</kbd><p>Select location in filtered list</p>
                     <kbd>A</kbd><p>Toggle Astro Atlas</p>
                     <kbd>M</kbd><p>Toggle Local Map</p>
                     <kbd>D</kbd><p>Toggle debug window</p>
@@ -141,7 +142,7 @@
                 </div>
 			</section>
 
-		   
+
 
 			<section>
 				<h2>Credits</h2>


### PR DESCRIPTION
This PR adds keyboard navigation and replaces #8.

- Using the arrow keys `up`/`down` allows navigating through the results. (`tab` and `shift+tab` can also be used)
- Improved the focus handling of the text input. (arrow keys would move the cursor, tab would select date picker)