### PR TITLE
Avoid duplicate location for abandoned outposts

### DIFF
--- a/classes/app/UserInterface.js
+++ b/classes/app/UserInterface.js
@@ -261,7 +261,7 @@ class UserInterface {
 			UI.setText('chosen-time', '');
 			UI.setText('chosen-time-sublabel', '');
 		}
-		UI.setText('location-name', Settings.activeLocation.NAME);
+		UI.setText('location-name', Settings.activeLocation.NAME.split(" (")[0]);
 		UI.setText('location-body-name', Settings.activeLocation.PARENT.NAME);
 	}
 


### PR DESCRIPTION
This avoids titles like "Abandoned Outpost (Yela), Yela", same for the other moons.
![image](https://github.com/dydrmr/VerseTime/assets/85351662/c193e451-3541-499a-972d-aaaa6e580dec)
